### PR TITLE
fix build error

### DIFF
--- a/javadocset.go
+++ b/javadocset.go
@@ -3,7 +3,7 @@ package javadocset
 import (
 	"code.google.com/p/go-html-transform/css/selector"
 	"code.google.com/p/go-html-transform/h5"
-	"code.google.com/p/go.net/html"
+	"golang.org/x/net/html"
 	"database/sql"
 	"errors"
 	_ "github.com/mattn/go-sqlite3" // Included for sqlite3 driver support


### PR DESCRIPTION
I got this error when I built this repository by go 1.5.

``` console
$  go build
# github.com/samcday/go-dash-javadocset
./javadocset.go:98: cannot use node (type *"golang.org/x/net/html".Node) as type *"code.google.com/p/go.net/html".Node in argument to nodeText
./javadocset.go:141: cannot use anchor (type *"golang.org/x/net/html".Node) as type *"code.google.com/p/go.net/html".Node in argument to nodeText
./javadocset.go:142: cannot use anchor (type *"golang.org/x/net/html".Node) as type *"code.google.com/p/go.net/html".Node in argument to nodeAttr
```

So I fix import statement and built success.
